### PR TITLE
Switch to Jekyll's default markdown renderer and highlighter

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,5 @@
 title: Society of Software Engineers
-markdown: redcarpet
 future:   true
-higlighter: pygments
 
 paginate: 5
 paginate_path: blog/:num
@@ -9,10 +7,6 @@ exclude: ["Gemfile", "Gemfile.lock", "package.json", ".sass-cache", ".gitignore"
 
 gems:
   - octopress-autoprefixer
-
-redcarpet:
-  extensions:
-    - tables
 
 sass:
   sass_dir: assets/css


### PR DESCRIPTION
This switches our markdown renderer to Kramdown, which is awesome. For more information, see [this comment](https://github.com/poole/poole/pull/58#issue-44731933).

## Caution
If you plan on merging this, please merge rit-sse/crazy-train#35 (updates Jekyll so these configuration changes will work properly) and rit-sse/crazy-train-pages#1 (fixes some posts that were broken by the switch to Kramdown) __first__. You will also need to update the submodule for [crazy-train-pages](https://github.com/rit-sse/crazy-train-pages).